### PR TITLE
[REFACTOR] user 다듬기

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     container_name: toyproject-team5
     build: .
+    restart: always
     ports:
       - "8080:8080"
     depends_on:
@@ -20,7 +21,7 @@ services:
       REDIS_PORT: 6379
 
       # 3. 기타 설정
-      JWT_SECRET: "secret-key-for-local-development-only"
+      JWT_SECRET: "your_default_dev_secret_key_more_than_32_characters"
       S3_BUCKET_NAME: "dummy-bucket"
 
   mysql:

--- a/src/main/kotlin/com/team5/studygroup/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team5/studygroup/config/SecurityConfig.kt
@@ -30,8 +30,9 @@ class SecurityConfig(
                     "/swagger-ui/**",
                     "/api/v3/api-docs/**",
                     "/v3/api-docs/**",
+                    "/api/auth/signup",
+                    "/api/auth/login",
                 ).permitAll()
-                    .requestMatchers("/members/login", "/members/signup").anonymous()
                     .anyRequest().authenticated()
             }
             .addFilterBefore(

--- a/src/main/kotlin/com/team5/studygroup/config/WebConfig.kt
+++ b/src/main/kotlin/com/team5/studygroup/config/WebConfig.kt
@@ -1,14 +1,20 @@
 package com.team5.studygroup.config
 
+import com.team5.studygroup.user.LoggedInUserResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.method.HandlerTypePredicate
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class WebConfig(private val loggedInUserResolver: LoggedInUserResolver) : WebMvcConfigurer {
     override fun configurePathMatch(configurer: PathMatchConfigurer) {
         configurer.addPathPrefix("/api", HandlerTypePredicate.forAnnotation(RestController::class.java))
+    }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(loggedInUserResolver)
     }
 }

--- a/src/main/kotlin/com/team5/studygroup/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/team5/studygroup/jwt/JwtTokenProvider.kt
@@ -1,91 +1,59 @@
 package com.team5.studygroup.jwt
 
-import com.team5.studygroup.user.dto.TokenInfo
+import com.team5.studygroup.user.service.CustomUserDetailsService
 import io.jsonwebtoken.Claims
-import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.SignatureAlgorithm
-import io.jsonwebtoken.UnsupportedJwtException
-import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
-import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.core.userdetails.User
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
 import java.util.Date
 
-const val EXPIRATION_MILLISECONDS: Long = 1000 * 60 * 30
-
 @Component
-class JwtTokenProvider {
+class JwtTokenProvider(
     @Value("\${jwt.secret}")
-    lateinit var secretKey: String
-
-    private val key by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey)) }
-
-    fun createToken(authentication: Authentication): TokenInfo {
-        val authorities: String =
-            authentication
-                .authorities
-                .joinToString(",", transform = GrantedAuthority::getAuthority)
-        val now = Date()
-        val accessExpiration = Date(now.time + EXPIRATION_MILLISECONDS)
-
-        val accessToken =
-            Jwts
-                .builder()
-                .setSubject(authentication.name)
-                .claim("auth", authorities)
-                .setIssuedAt(now)
-                .setExpiration(accessExpiration)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact()
-
-        return TokenInfo("Bearer", accessToken)
+    private val secretKey: String,
+    @Value("\${jwt.expiration-time}")
+    private val expirationInMs: Long,
+    private val userDetailsService: CustomUserDetailsService,
+) {
+    // [수정됨] Base64 디코딩 제거 -> 일반 문자열을 바이트로 변환
+    private val key by lazy {
+        Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
     }
 
-    fun getAuthentication(token: String): Authentication {
-        val claims: Claims = getClaims(token)
-        val auth = claims["auth"] ?: throw RuntimeException("잘못된 토큰입니다.")
-        val authorities: Collection<GrantedAuthority> =
-            (auth as String)
-                .split(",")
-                .map { SimpleGrantedAuthority(it) }
-        val principal: UserDetails = User(claims.subject, "", authorities)
+    // ... 아래 코드는 그대로 두셔도 됩니다 ...
 
-        return UsernamePasswordAuthenticationToken(principal, "", authorities)
+    fun createToken(username: String): String {
+        val now = Date()
+        val validity = Date(now.time + expirationInMs)
+
+        return Jwts.builder()
+            .setSubject(username)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    // ... 나머지 함수들 (getUsername, getAuthentication, validateToken, getClaims) 그대로 유지 ...
+    fun getUsername(token: String): String = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body.subject
+
+    fun getAuthentication(token: String): Authentication {
+        val username = getUsername(token)
+        val userDetails = userDetailsService.loadUserByUsername(username)
+        return UsernamePasswordAuthenticationToken(userDetails, token, userDetails.authorities)
     }
 
     fun validateToken(token: String): Boolean {
-        try {
-            getClaims(token)
-            return true
-        } catch (e: Exception) {
-            when (e) {
-                is SecurityException,
-                is MalformedJwtException,
-                is ExpiredJwtException,
-                is UnsupportedJwtException,
-                is IllegalArgumentException,
-                -> {
-                    return false
-                }
-                else -> throw e
-            }
-        }
+        getClaims(token)
+        return true
     }
 
     private fun getClaims(token: String): Claims {
-        return Jwts
-            .parserBuilder()
-            .setSigningKey(key)
-            .build()
-            .parseClaimsJws(token)
-            .body
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
     }
 }

--- a/src/main/kotlin/com/team5/studygroup/user/LoggedInUserResolver.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/LoggedInUserResolver.kt
@@ -1,0 +1,46 @@
+package com.team5.studygroup.user
+
+import com.team5.studygroup.user.model.CustomUserDetails
+import com.team5.studygroup.user.model.User
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class LoggedInUserResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        val hasAnnotation = parameter.hasParameterAnnotation(LoggedInUser::class.java)
+        val type = parameter.parameterType
+
+        // @LoggedInUser가 붙어있고, 타입이 Long이거나 User인 경우 지원
+        return hasAnnotation && (
+            type == Long::class.java ||
+                type == Long::class.javaObjectType ||
+                type == User::class.java
+        )
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Any? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val principal = authentication?.principal
+
+        if (principal is CustomUserDetails) {
+            return if (parameter.parameterType == User::class.java) {
+                principal.getUserEntity()
+            } else {
+                principal.id
+            }
+        }
+
+        return null
+    }
+}

--- a/src/main/kotlin/com/team5/studygroup/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/controller/AuthController.kt
@@ -1,7 +1,9 @@
 package com.team5.studygroup.user.controller
 
 import com.team5.studygroup.user.dto.LoginDto
+import com.team5.studygroup.user.dto.LoginResponseDto
 import com.team5.studygroup.user.dto.SignUpDto
+import com.team5.studygroup.user.dto.SignUpResponseDto
 import com.team5.studygroup.user.service.UserService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -12,19 +14,21 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/auth")
 class AuthController(
-    private val memberService: UserService,
     private val userService: UserService,
 ) {
     @PostMapping("/signup")
     fun signUp(
         @RequestBody signUpDto: SignUpDto,
-    ): String = memberService.signUp(signUpDto)
+    ): ResponseEntity<SignUpResponseDto> { // String 대신 DTO 반환
+        val response = userService.signUp(signUpDto)
+        return ResponseEntity.ok(response)
+    }
 
     @PostMapping("/login")
     fun login(
         @RequestBody loginDto: LoginDto,
-    ): ResponseEntity<String> {
-        val result = userService.login(loginDto)
-        return ResponseEntity.ok(result) // 이제 String을 반환하므로 에러가 사라집니다.
+    ): ResponseEntity<LoginResponseDto> { // LoginResponseDto로 타입 일치
+        val response = userService.login(loginDto)
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/team5/studygroup/user/controller/UserController.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/controller/UserController.kt
@@ -1,14 +1,13 @@
 package com.team5.studygroup.user.controller
 
 import com.team5.studygroup.user.LoggedInUser
-import com.team5.studygroup.user.dto.CreateProfileDto
 import com.team5.studygroup.user.dto.GetProfileDto
 import com.team5.studygroup.user.dto.UpdateProfileDto
 import com.team5.studygroup.user.service.ProfileService
+import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -18,24 +17,11 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     private val profileService: ProfileService,
 ) {
-    /**
-     * POST 최초 프로필 생성 (회원가입/인증 후 단계)
-     * 학번이 포함되며, 이후 수정이 불가능함
-     */
-    @PostMapping("")
-    fun createProfile(
-        @RequestBody createProfileDto: CreateProfileDto,
-        @LoggedInUser userId: Long,
-    ): ResponseEntity<GetProfileDto> {
-        val response = profileService.createProfile(userId, createProfileDto)
-        return ResponseEntity.ok(response)
-    }
-
     // 프로필 수정
     @PatchMapping("")
     fun updateProfile(
         @RequestBody updateProfileDto: UpdateProfileDto,
-        @LoggedInUser userId: Long,
+        @Parameter(hidden = true) @LoggedInUser userId: Long,
     ): ResponseEntity<GetProfileDto> {
         val response = profileService.updateProfile(userId, updateProfileDto)
         return ResponseEntity.ok(response)
@@ -44,7 +30,7 @@ class UserController(
     // 프로필 조회
     @GetMapping("")
     fun getProfile(
-        @LoggedInUser userId: Long,
+        @Parameter(hidden = true) @LoggedInUser userId: Long,
     ): ResponseEntity<GetProfileDto> {
         val response = profileService.getProfile(userId = userId)
         return ResponseEntity.ok(response)

--- a/src/main/kotlin/com/team5/studygroup/user/dto/CreateProfileDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/dto/CreateProfileDto.kt
@@ -1,9 +1,0 @@
-package com.team5.studygroup.user.dto
-
-data class CreateProfileDto(
-    val studentNumber: String,
-    val major: String,
-    val nickname: String,
-    val profileImageUrl: String? = null,
-    val bio: String? = null,
-)

--- a/src/main/kotlin/com/team5/studygroup/user/dto/GetProfileDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/dto/GetProfileDto.kt
@@ -6,12 +6,12 @@ import java.time.Instant
 data class GetProfileDto(
     val userId: Long?,
     val username: String,
-    val email: String,
-    val major: String?,
-    val studentNumber: String?,
-    val nickname: String?,
+    val major: String,
+    val studentNumber: String,
+    val nickname: String,
     val profileImageUrl: String?,
     val bio: String?,
+    val role: String,
     val createdAt: Instant?,
 ) {
     companion object {
@@ -20,12 +20,12 @@ data class GetProfileDto(
             return GetProfileDto(
                 userId = user.id,
                 username = user.username,
-                email = user.email,
                 major = user.major,
                 studentNumber = user.studentNumber,
                 nickname = user.nickname,
                 profileImageUrl = user.profileImageUrl,
                 bio = user.bio,
+                role = user.userRole.description,
                 createdAt = user.createdAt,
             )
         }

--- a/src/main/kotlin/com/team5/studygroup/user/dto/LoginDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/dto/LoginDto.kt
@@ -1,6 +1,6 @@
 package com.team5.studygroup.user.dto
 
 data class LoginDto(
-    val account: String,
+    val username: String,
     val password: String,
 )

--- a/src/main/kotlin/com/team5/studygroup/user/dto/LoginResponseDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/dto/LoginResponseDto.kt
@@ -1,0 +1,7 @@
+package com.team5.studygroup.user.dto
+
+data class LoginResponseDto(
+    val accessToken: String,
+    val nickname: String,
+    val isVerified: Boolean,
+)

--- a/src/main/kotlin/com/team5/studygroup/user/dto/SignUpDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/dto/SignUpDto.kt
@@ -3,7 +3,6 @@ package com.team5.studygroup.user.dto
 data class SignUpDto(
     val username: String,
     val password: String,
-    val email: String,
     val major: String,
     val studentNumber: String,
     val nickname: String,

--- a/src/main/kotlin/com/team5/studygroup/user/dto/SignUpResponseDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/dto/SignUpResponseDto.kt
@@ -1,0 +1,8 @@
+package com.team5.studygroup.user.dto
+
+data class SignUpResponseDto(
+    val accessToken: String,
+    val username: String,
+    val nickname: String,
+    val isVerified: Boolean,
+)

--- a/src/main/kotlin/com/team5/studygroup/user/model/CustomUserDetails.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/model/CustomUserDetails.kt
@@ -1,4 +1,5 @@
-import com.team5.studygroup.user.model.User
+package com.team5.studygroup.user.model
+
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
@@ -6,12 +7,15 @@ import org.springframework.security.core.userdetails.UserDetails
 class CustomUserDetails(private val user: User) : UserDetails {
     // This custom property is how we'll access the user's ID.
     // The SpEL expression `expression = "id"` will resolve to this.
+
+    fun getUserEntity(): User = user
+
     val id: Long
         get() = user.id!!
 
     override fun getAuthorities(): Collection<GrantedAuthority> =
         // You would typically load roles from your user object
-        listOf(SimpleGrantedAuthority("ROLE_USER"))
+        listOf(SimpleGrantedAuthority(user.userRole.key))
 
     override fun getPassword(): String? = user.password
 
@@ -25,5 +29,5 @@ class CustomUserDetails(private val user: User) : UserDetails {
 
     override fun isCredentialsNonExpired(): Boolean = true
 
-    override fun isEnabled(): Boolean = true
+    override fun isEnabled(): Boolean = user.isVerified
 }

--- a/src/main/kotlin/com/team5/studygroup/user/model/Role.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/model/Role.kt
@@ -1,0 +1,6 @@
+package com.team5.studygroup.user.model
+
+enum class Role(val key: String, val description: String) {
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자"),
+}

--- a/src/main/kotlin/com/team5/studygroup/user/model/User.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/model/User.kt
@@ -3,6 +3,8 @@ package com.team5.studygroup.user.model
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -23,26 +25,28 @@ class User(
     var username: String,
     @Column(nullable = true)
     var password: String? = null,
-    @Column(nullable = false, unique = true)
-    var email: String,
     // 학과
-    @Column(nullable = true)
-    var major: String? = null,
+    @Column(nullable = false)
+    var major: String,
     // 학번
-    @Column(nullable = true, unique = true)
-    var studentNumber: String? = null,
+    @Column(nullable = false, unique = true)
+    var studentNumber: String,
     // 닉네임
-    @Column(nullable = true, unique = true)
-    var nickname: String? = null,
+    @Column(nullable = false, unique = true)
+    var nickname: String,
     // 인증 여부
-    @Column(nullable = true)
-    var isVerified: Boolean? = false,
+    @Column(nullable = false)
+    var isVerified: Boolean = false,
     // 프로필 이미지 경로
     @Column(length = 512, nullable = true)
     var profileImageUrl: String? = null,
     // 자기소개
     @Column(columnDefinition = "TEXT", nullable = true)
     var bio: String? = null,
+    // 권한
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false)
+    var userRole: Role = Role.USER,
     @CreatedDate
     @Column(nullable = false, updatable = false)
     var createdAt: Instant? = null,
@@ -63,18 +67,5 @@ class User(
         this.bio = bio ?: this.bio
     }
 
-    // 최초 등록용: 학번까지 포함
-    fun registerProfile(
-        studentNumber: String,
-        major: String,
-        nickname: String,
-        profileImageUrl: String?,
-        bio: String?,
-    ) {
-        this.studentNumber = studentNumber
-        this.major = major
-        this.nickname = nickname
-        this.profileImageUrl = profileImageUrl
-        this.bio = bio
-    }
+    fun isAdmin(): Boolean = this.userRole == Role.ADMIN
 }

--- a/src/main/kotlin/com/team5/studygroup/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/repository/UserRepository.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface UserRepository : JpaRepository<User, Long> {
     // 닉네임이나 이메일로 유저를 찾는 쿼리는 함수 이름만 정해주면 JPA가 알아서 SQL을 만듭니다.
-    fun findByEmail(email: String): User?
 
     fun findByUsername(username: String): User?
 

--- a/src/main/kotlin/com/team5/studygroup/user/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/service/CustomUserDetailsService.kt
@@ -1,26 +1,18 @@
 package com.team5.studygroup.user.service
 
+import com.team5.studygroup.user.model.CustomUserDetails
 import com.team5.studygroup.user.repository.UserRepository
-import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class CustomUserDetailsService(
     private val userRepository: UserRepository,
-    private val passwordEncoder: PasswordEncoder,
 ) : UserDetailsService {
     override fun loadUserByUsername(username: String): UserDetails =
         userRepository.findByUsername(username)
-            ?.let { createUserDetails(it) }
-            ?: throw UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다.")
-
-    private fun createUserDetails(user: com.team5.studygroup.user.model.User): UserDetails =
-        User.builder()
-            .username(user.username)
-            .password(passwordEncoder.encode(user.password))
-            .build()
+            ?.let { user -> CustomUserDetails(user) }
+            ?: throw UsernameNotFoundException("사용자($username)를 찾을 수 없습니다.")
 }

--- a/src/main/kotlin/com/team5/studygroup/user/service/ProfileService.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/service/ProfileService.kt
@@ -1,9 +1,7 @@
 package com.team5.studygroup.user.service
 
 import com.team5.studygroup.user.NicknameDuplicateException
-import com.team5.studygroup.user.StudentNumberDuplicateException
 import com.team5.studygroup.user.UserNotFoundException
-import com.team5.studygroup.user.dto.CreateProfileDto
 import com.team5.studygroup.user.dto.GetProfileDto
 import com.team5.studygroup.user.dto.UpdateProfileDto
 import com.team5.studygroup.user.repository.UserRepository
@@ -14,41 +12,6 @@ import org.springframework.transaction.annotation.Transactional
 class ProfileService(
     private val userRepository: UserRepository,
 ) {
-    /**
-     * 최초 프로필 등록 (학번 입력 필수, 중복 검사)
-     */
-    @Transactional
-    fun createProfile(
-        userId: Long,
-        dto: CreateProfileDto,
-    ): GetProfileDto {
-        // 1. 사용자 조회
-        val user =
-            userRepository.findById(userId)
-                .orElseThrow { UserNotFoundException() }
-
-        // 1. 학번 중복 체크 (최초 등록 시에만 수행)
-        if (userRepository.existsByStudentNumber(dto.studentNumber)) {
-            throw StudentNumberDuplicateException()
-        }
-
-        // 2. 닉네임 중복 체크
-        if (userRepository.existsByNickname(dto.nickname)) {
-            throw NicknameDuplicateException()
-        }
-
-        // 3. 전체 정보 업데이트
-        user.registerProfile(
-            studentNumber = dto.studentNumber,
-            major = dto.major,
-            nickname = dto.nickname,
-            profileImageUrl = dto.profileImageUrl,
-            bio = dto.bio,
-        )
-
-        return GetProfileDto.fromEntity(user)
-    }
-
     /**
      * 프로필 수정 (학번 수정 불가)
      * 수정된 결과를 GetProfileDto로 반환하여 즉시 클라이언트가 반영할 수 있게 함

--- a/src/main/kotlin/com/team5/studygroup/user/service/UserService.kt
+++ b/src/main/kotlin/com/team5/studygroup/user/service/UserService.kt
@@ -1,9 +1,14 @@
 package com.team5.studygroup.user.service
 
+import com.team5.studygroup.jwt.JwtTokenProvider
 import com.team5.studygroup.user.dto.LoginDto
+import com.team5.studygroup.user.dto.LoginResponseDto
 import com.team5.studygroup.user.dto.SignUpDto
+import com.team5.studygroup.user.dto.SignUpResponseDto
+import com.team5.studygroup.user.model.Role
 import com.team5.studygroup.user.model.User
 import com.team5.studygroup.user.repository.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,17 +16,21 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class UserService(
     private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder,
 //    private val authenticationManagerBuilder: AuthenticationManagerBuilder,
-//    private val jwtTokenProvider: JwtTokenProvider,
+    private val jwtTokenProvider: JwtTokenProvider,
 ) {
     @Transactional
-    fun signUp(signUpDto: SignUpDto): String {
-        // 1. 중복 체크 (아이디뿐만 아니라 이메일, 닉네임도 체크하는 것이 안전합니다)
+    fun signUp(signUpDto: SignUpDto): SignUpResponseDto {
+        // 1. 중복 체크 (아이디뿐만 아니라 닉네임도 체크하는 것이 안전합니다)
         if (userRepository.findByUsername(signUpDto.username) != null) {
             throw Exception("이미 등록된 아이디입니다.")
         }
-        if (userRepository.findByEmail(signUpDto.email) != null) {
-            throw Exception("이미 등록된 이메일입니다.")
+        if (userRepository.existsByNickname(signUpDto.nickname)) {
+            throw Exception("이미 등록된 닉네임입니다.")
+        }
+        if (userRepository.existsByStudentNumber(signUpDto.studentNumber)) {
+            throw Exception("이미 등록된 학번입니다.")
         }
 
         // 2. 유저 객체 생성
@@ -29,27 +38,46 @@ class UserService(
         val member =
             User(
                 username = signUpDto.username,
-                password = signUpDto.password,
+                password = passwordEncoder.encode(signUpDto.password),
                 // TODO: BCryptPasswordEncoder로 암호화 필요!
-                email = signUpDto.email,
                 major = signUpDto.major,
                 studentNumber = signUpDto.studentNumber,
                 nickname = signUpDto.nickname,
                 // 닉네임 없으면 아이디로
-                isVerified = false,
+                isVerified = true,
                 profileImageUrl = null,
+                userRole = Role.USER,
                 bio = null,
             )
-
         userRepository.save(member)
-        return "${member.username}님, 회원가입이 완료되었습니다."
+        val accessToken = jwtTokenProvider.createToken(member.username)
+        return SignUpResponseDto(
+            accessToken = accessToken,
+            username = member.username,
+            nickname = member.nickname,
+            isVerified = member.isVerified,
+        )
     }
 
-    fun login(loginDto: LoginDto): String {
+    fun login(loginDto: LoginDto): LoginResponseDto {
         // "일단 JWT 안 쓸 거야"라고 하셨으므로,
         // 만약 JWT 설정이 미비하다면 이 부분에서 에러가 날 수 있습니다.
         // API 설정만 확인하시려면 이 메서드는 잠시 비워두거나 더미 토큰을 반환하게 해도 됩니다.
-        return "JWT 설정 전입니다."
+        val member =
+            userRepository.findByUsername(loginDto.username)
+                ?: throw IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다.")
+
+        if (!passwordEncoder.matches(loginDto.password, member.password)) {
+            throw IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다.")
+        }
+
+        val accessToken = jwtTokenProvider.createToken(member.username)
+
+        return LoginResponseDto(
+            accessToken = accessToken,
+            nickname = member.nickname,
+            isVerified = member.isVerified,
+        )
 
 //        val authenticationToken = UsernamePasswordAuthenticationToken(loginDto.account, loginDto.password)
 //        val authentication = authenticationManagerBuilder.`object`.authenticate(authenticationToken)

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     # 로컬 도커용 3307 포트
-    url: jdbc:mysql://localhost:3307/toyproject-team5?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
-    username: waffle
-    password: somepassword # 본인 로컬 DB 비번
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3307}/${DB_NAME:toyproject-team5}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: ${DB_USER:waffle}
+    password: ${DB_PASSWORD:somepassword} # 본인 로컬 DB 비번
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/src/main/resources/db.migration/V1__create_table_users.sql
+++ b/src/main/resources/db.migration/V1__create_table_users.sql
@@ -3,13 +3,13 @@ CREATE TABLE IF NOT EXISTS users
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     username VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255),
-    email VARCHAR(255) NOT NULL UNIQUE,
     major VARCHAR(255) NOT NULL,
     student_number VARCHAR(255) NOT NULL UNIQUE,
     nickname VARCHAR(255) NOT NULL UNIQUE,
     is_verified BOOLEAN NOT NULL,
     profile_image_url VARCHAR(512),
     bio TEXT,
+    user_role VARCHAR(20)  NOT NULL,
     created_at TIMESTAMP,
     updated_at TIMESTAMP
 );


### PR DESCRIPTION
user 패키지 refactoring했습니다.

1. 제가 생각하기에 username이 있으면 소셜로그인과의 관계가 조금 애매해질 거 같아서 기존 username을 제거하고 대신 email(스누메일)이 username 역할을 할 수 있도록 했습니다.

2. 또 Role column을 추가하여 관리자와 일반 유저의 구분이 가능하도록 했습니다.

3. 일반적인 회원가입의 경우 snu메일로만 하도록 만드는 게 좋을 것 같습니다. 

4. 학번, 학과, 닉네임은 회원가입할 때 반드시 null이 아닌 값을 받도록 만들었고, 학번의 경우 절대 수정이 불가하게,
학과와 닉네임은 수정이 가능하도록 만들었습니다.

5. createProfileDto가 updateProfileDto에 포함될 수 있다고 판단하여 createProfile를 controller, dto, service에서 제거했습니다.

swagger에서 수정된 api/auth, api/users 부분을 확인하실 수 있으니 보시고 괜찮으면 merge해주시기 바랍니다.