### PR TITLE
GroupService 구현

### DIFF
--- a/src/main/kotlin/com/team5/studygroup/group/GroupStatus.kt
+++ b/src/main/kotlin/com/team5/studygroup/group/GroupStatus.kt
@@ -1,0 +1,6 @@
+package com.team5.studygroup.group
+
+enum class GroupStatus(val description: String) {
+    RECRUITING("모집중"),
+    EXPIRED("만료됨"),
+}

--- a/src/main/kotlin/com/team5/studygroup/group/controller/GroupController.kt
+++ b/src/main/kotlin/com/team5/studygroup/group/controller/GroupController.kt
@@ -4,6 +4,8 @@ import com.team5.studygroup.group.dto.CreateGroupDto
 import com.team5.studygroup.group.dto.DeleteGroupDto
 import com.team5.studygroup.group.dto.ExpireGroupDto
 import com.team5.studygroup.group.service.GroupService
+import com.team5.studygroup.user.LoggedInUser
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -19,21 +21,24 @@ class GroupController(
     @PostMapping("")
     fun createGroup(
         @RequestBody createGroupDto: CreateGroupDto,
-    ): String {
-        return groupService.createGroup(createGroupDto)
+        @LoggedInUser requestingUserId: Long,
+    ): ResponseEntity<Unit> {
+        return ResponseEntity.ok(groupService.createGroup(createGroupDto, requestingUserId))
     }
 
     @DeleteMapping("")
     fun deleteGroup(
         @RequestBody deleteGroupDto: DeleteGroupDto,
-    ): String {
-        return groupService.deleteGroup(deleteGroupDto)
+        @LoggedInUser requestingUserId: Long,
+    ): ResponseEntity<Unit> {
+        return ResponseEntity.ok(groupService.deleteGroup(deleteGroupDto, requestingUserId))
     }
 
     @PatchMapping("/expire")
     fun expireGroup(
         @RequestBody expireGroupDto: ExpireGroupDto,
-    ): String {
-        return groupService.expireGroup(expireGroupDto)
+        @LoggedInUser requestingUserId: Long,
+    ): ResponseEntity<Unit> {
+        return ResponseEntity.ok(groupService.expireGroup(expireGroupDto, requestingUserId))
     }
 }

--- a/src/main/kotlin/com/team5/studygroup/group/dto/CreateGroupDto.kt
+++ b/src/main/kotlin/com/team5/studygroup/group/dto/CreateGroupDto.kt
@@ -6,8 +6,6 @@ data class CreateGroupDto(
     val categoryId: Long,
     val subCategoryId: Long,
     val capacity: Int? = null,
-    val leaderId: Long? = null,
     val isOnline: Boolean,
     val location: String,
-    val status: String,
 )

--- a/src/main/kotlin/com/team5/studygroup/group/exception/GroupException.kt
+++ b/src/main/kotlin/com/team5/studygroup/group/exception/GroupException.kt
@@ -1,0 +1,32 @@
+package com.team5.studygroup.group.exception
+
+import com.team5.studygroup.DomainException
+import org.springframework.http.HttpStatus
+
+sealed class GroupException(
+    errorCode: Int,
+    httpStatusCode: HttpStatus,
+    msg: String,
+    cause: Throwable? = null,
+) : DomainException(errorCode, httpStatusCode, msg, cause)
+
+// 그룹을 찾을 수 없을 때
+class GroupNotFoundException : GroupException(
+    // 그룹 관련 에러는 2000번대로 규칙을 정하면 좋습니다
+    errorCode = 2001,
+    httpStatusCode = HttpStatus.NOT_FOUND,
+    msg = "해당 스터디 그룹을 찾을 수 없습니다.",
+)
+
+// 그룹장이 아닌 사용자가 권한이 필요한 작업을 시도할 때
+class NotGroupLeaderException : GroupException(
+    errorCode = 2002,
+    httpStatusCode = HttpStatus.FORBIDDEN,
+    msg = "스터디 그룹장만 이 작업을 수행할 수 있습니다.",
+)
+
+class GroupAlreadyExpiredException : GroupException(
+    errorCode = 2003,
+    httpStatusCode = HttpStatus.CONFLICT,
+    msg = "이미 만료된 스터디 그룹입니다.",
+)

--- a/src/main/kotlin/com/team5/studygroup/group/model/Group.kt
+++ b/src/main/kotlin/com/team5/studygroup/group/model/Group.kt
@@ -1,5 +1,6 @@
 package com.team5.studygroup.group.model
 
+import com.team5.studygroup.group.GroupStatus
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
@@ -29,10 +30,14 @@ class Group(
     val leaderId: Long? = null,
     val isOnline: Boolean,
     val location: String,
-    val status: String,
+    var status: GroupStatus,
     @CreatedDate
     @Column(updatable = false)
     val createdAt: Instant? = null,
     @LastModifiedDate
     val updatedAt: Instant? = null,
-)
+) {
+    fun expire() {
+        this.status = GroupStatus.EXPIRED
+    }
+}

--- a/src/main/kotlin/com/team5/studygroup/group/service/GroupService.kt
+++ b/src/main/kotlin/com/team5/studygroup/group/service/GroupService.kt
@@ -1,21 +1,78 @@
 package com.team5.studygroup.group.service
 
+import com.team5.studygroup.group.GroupStatus
 import com.team5.studygroup.group.dto.CreateGroupDto
 import com.team5.studygroup.group.dto.DeleteGroupDto
 import com.team5.studygroup.group.dto.ExpireGroupDto
+import com.team5.studygroup.group.exception.GroupAlreadyExpiredException
+import com.team5.studygroup.group.exception.GroupNotFoundException
+import com.team5.studygroup.group.exception.NotGroupLeaderException
+import com.team5.studygroup.group.model.Group
+import com.team5.studygroup.group.repository.GroupRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class GroupService {
-    fun createGroup(createGroupDto: CreateGroupDto): String {
-        return "그룹 생성 완료"
+class GroupService(
+    private val groupRepository: GroupRepository,
+) {
+    @Transactional
+    fun createGroup(
+        createGroupDto: CreateGroupDto,
+        requestingUserId: Long,
+    ) {
+        groupRepository.save(
+            Group(
+                groupName = createGroupDto.groupName,
+                description = createGroupDto.description,
+                categoryId = createGroupDto.categoryId,
+                subCategoryId = createGroupDto.subCategoryId,
+                capacity = createGroupDto.capacity,
+                leaderId = requestingUserId,
+                isOnline = createGroupDto.isOnline,
+                location = createGroupDto.location,
+                status = GroupStatus.RECRUITING,
+            ),
+        )
     }
 
-    fun deleteGroup(deleteGroupDto: DeleteGroupDto): String {
-        return "그룹 삭제 완료"
+    @Transactional
+    fun deleteGroup(
+        deleteGroupDto: DeleteGroupDto,
+        requestingUserId: Long,
+    ) {
+        val group =
+            groupRepository.findByIdOrNull(deleteGroupDto.groupId)
+                ?: throw GroupNotFoundException()
+
+        // 삭제를 요청한 사용자가 그룹장인 경우에만 허용
+        if (group.leaderId != requestingUserId) {
+            throw NotGroupLeaderException()
+        }
+
+        groupRepository.delete(group)
     }
 
-    fun expireGroup(expireGroupDto: ExpireGroupDto): String {
-        return "그룹 마감 완료"
+    @Transactional
+    fun expireGroup(
+        expireGroupDto: ExpireGroupDto,
+        requestingUserId: Long,
+    ) {
+        val group =
+            groupRepository.findByIdOrNull(expireGroupDto.groupId)
+                ?: throw GroupNotFoundException()
+
+        // 만료를 요청한 사용자가 그룹장인 경우에만 허용
+        if (group.leaderId != requestingUserId) {
+            throw NotGroupLeaderException()
+        }
+
+        // 이미 만료된 그룹은 다시 만료시킬 수 없음
+        if (group.status == GroupStatus.EXPIRED) {
+            throw GroupAlreadyExpiredException()
+        }
+
+        group.expire()
     }
 }


### PR DESCRIPTION
1. GroupService의 CreateGroup, DeleteGroup, ExpireGroup 구현
2. GroupStatus Enum 추가
3. CreateGroupDto에서 leaderId와 status 삭제, leaderId는 loggedInUser에서 요청한 user의 id를 받는 것으로 대체, status는 처음에는 GroupStatus.OPEN으로 설정
4. Group의 status를 val에서 var로 수정, expire 메소드 추가
5. GroupException 추가(코드는 2000번대)